### PR TITLE
Allowing CLI to return success when Jenkins node is running on Windows

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -68,15 +68,8 @@ class CommandLine {
         }
 
         const jflint = new JFLint(jenkinsUrl, username, password, csrfDisabled);
-        return jflint.lintJenkinsfile(jenkinsfile).then(res => {
-            if (res === 'Jenkinsfile successfully validated.\n') {
-                this._process.stdout.write(res);
-                this._process.exit(0);
-            } else {
-                this._process.stderr.write(res);
-                this._process.exit(1);
-            }
-        }).catch(e => {
+        return jflint.lintJenkinsfile(jenkinsfile).then(this._interpretResult)
+        .catch(e => {
             this._process.stderr.write(`${e.message}\n`);
             this._process.exit(1);
         });
@@ -104,6 +97,16 @@ class CommandLine {
         } catch (e) {
             return false;
         }
+    }
+
+    _interpretResult(res) {
+      if (/^Jenkinsfile successfully validated.\r?\n$/.test(res)) {
+          this._process.stdout.write(res);
+          this._process.exit(0);
+      } else {
+          this._process.stderr.write(res);
+          this._process.exit(1);
+      }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,11 +35,14 @@
     "node-fetch": "^1.6.3"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "coveralls": "^2.11.16",
     "intelli-espower-loader": "^1.0.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "power-assert": "^1.4.2",
-    "proxyquire": "^1.7.11"
+    "proxyquire": "^1.7.11",
+    "sinon": "^7.0.0",
+    "sinon-chai": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "mocha": "^3.2.0",
     "power-assert": "^1.4.2",
     "proxyquire": "^1.7.11",
-    "sinon": "^7.0.0",
+    "sinon": "6.3.5",
     "sinon-chai": "^3.2.0"
   }
 }

--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -4,6 +4,9 @@ const CommandLine = require('../../lib/cli');
 const assert = require('assert');
 const os = require('os');
 const path = require('path');
+const sinon = require('sinon');
+const chai = require('chai');
+chai.use(require('sinon-chai'));
 
 describe('CommandLine', function() {
     let sut;
@@ -31,6 +34,30 @@ describe('CommandLine', function() {
             // exercise & verify
             const dir = path.normalize(`${__dirname}`);
             assert(sut._findConfigPath(dir) === path.join(os.homedir(), '.jflintrc'));
+        });
+    });
+
+    describe('_interpretResult', function() {
+        beforeEach(function() {
+            sut._process = {
+                stdout: { write: sinon.stub() },
+                stderr: { write: sinon.stub() },
+                exit: sinon.stub()
+            };
+        });
+
+        it('should handle success response from Linux node', function() {
+            const res = 'Jenkinsfile successfully validated.\n';
+            sut._interpretResult(res);
+
+            chai.expect(sut._process.exit).to.be.calledWith(0);
+        });
+
+        it('should handle success response from Windows node', function() {
+            const res = 'Jenkinsfile successfully validated.\r\n';
+            sut._interpretResult(res);
+
+            chai.expect(sut._process.exit).to.be.calledWith(0);
         });
     });
 });


### PR DESCRIPTION
This change allows the CLI to return success (code 0) when the response returned from Jenkins contains CRLF line endings as happens on a Jenkins server running on Windows.

Unit test for this change is also included